### PR TITLE
feat: add validation for exchange swap step

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,15 @@ flows:
      id: usd-to-cust-binance
      description: "Go from USD held on binance to cUSD on Celo"
      steps:
+        - type: Exchange.Swap
+          adapter: ccxt
+          config:
+             exchange: binance
+             base: BTC
+             quote: USDT
+             side: Buy
+             maxSlippageBPS: 20
+             amount: 1000
         - type: Exchange.WithdrawCrypto
           adapter: ccxt
           config:

--- a/packages/adapter-ccxt/jest.config.ts
+++ b/packages/adapter-ccxt/jest.config.ts
@@ -10,7 +10,13 @@ const config: Config.InitialOptions = {
    testRegex: "test/.*\\.test\\.ts$",
    moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
    collectCoverage: true,
-   collectCoverageFrom: ["src/**/*.ts"],
+   collectCoverageFrom: [
+      "src/**/*.ts",
+      "!src/types/**/*",
+      "!src/constants/**/*",
+      "!src/**/ValidationError.ts",
+      "!src/**/index.ts",
+   ],
    coverageDirectory: "<rootDir>/coverage/",
    coveragePathIgnorePatterns: ["index.ts, src/constants, src/types"],
    moduleNameMapper: {

--- a/packages/adapter-ccxt/jest.config.ts
+++ b/packages/adapter-ccxt/jest.config.ts
@@ -19,9 +19,6 @@ const config: Config.InitialOptions = {
    ],
    coverageDirectory: "<rootDir>/coverage/",
    coveragePathIgnorePatterns: ["index.ts, src/constants, src/types"],
-   moduleNameMapper: {
-      "^@validation/(.*)$": "<rootDir>/src/validation/$1",
-   },
    testTimeout: 20000,
 };
 

--- a/packages/adapter-ccxt/src/CCXTStepConfig.ts
+++ b/packages/adapter-ccxt/src/CCXTStepConfig.ts
@@ -1,1 +1,0 @@
-export class CCXTStepConfig {}

--- a/packages/adapter-ccxt/src/DependencyRegistrar.ts
+++ b/packages/adapter-ccxt/src/DependencyRegistrar.ts
@@ -1,5 +1,5 @@
 import { container } from "tsyringe";
-import { IValidator, StepConfigValidator } from "./validation";
+import { StepConfigValidator } from "./validation";
 import { CCXTStep, StepType } from "./types";
 import {
    ExchangeServiceRepo,
@@ -12,6 +12,7 @@ import {
    WithdrawCryptoValidationStrategy,
 } from "./validation/strategies";
 import { VALIDATION_STRATEGIES_TOKEN } from "./constants";
+import { IValidator } from "@mate/sdk";
 
 /**
  * Handles the dependency registration for the adapter.

--- a/packages/adapter-ccxt/src/DependencyRegistrar.ts
+++ b/packages/adapter-ccxt/src/DependencyRegistrar.ts
@@ -11,7 +11,12 @@ import {
    ExchangeSwapValidationStrategy,
    WithdrawCryptoValidationStrategy,
 } from "./validation/strategies";
+import { VALIDATION_STRATEGIES_TOKEN } from "./constants";
 
+/**
+ * Handles the dependency registration for the adapter.
+ * This class ensures all dependencies are correctly set up and registered.
+ */
 export class DependencyRegistrar {
    private static instance: DependencyRegistrar | null = null;
 
@@ -25,17 +30,19 @@ export class DependencyRegistrar {
    }
 
    public configure(): void {
-      this.registerExchangeServices();
-      this.registerValidation();
+      this.registerExchangeServiceDependencies();
+      this.registerValidationDependencies();
    }
 
-   private registerValidation(): void {
+   /**
+    * Registers validation-related dependencies.
+    */
+   private registerValidationDependencies(): void {
       container.register<IValidator<CCXTStep>>(StepConfigValidator, {
          useClass: StepConfigValidator,
       });
 
-      // Register the valiation strategies
-      container.register("ValidationStrategies", {
+      container.register(VALIDATION_STRATEGIES_TOKEN, {
          useFactory: (c) => {
             const map = new Map();
             map.set(
@@ -51,14 +58,14 @@ export class DependencyRegistrar {
       });
    }
 
-   private registerExchangeServices(): void {
+   /**
+    * Registers exchange service-related dependencies.
+    */
+   private registerExchangeServiceDependencies(): void {
       container.registerSingleton<IExchangeServiceRepo>(ExchangeServiceRepo);
 
       container.register<IExchangeFactory>(ExchangeFactory, {
          useClass: ExchangeFactory,
       });
-
-      // Note: Individual exchange services are managed by the ExchangeServiceRepo repo,
-      // so we don't need to register them here
    }
 }

--- a/packages/adapter-ccxt/src/DependencyRegistrar.ts
+++ b/packages/adapter-ccxt/src/DependencyRegistrar.ts
@@ -1,0 +1,64 @@
+import { container } from "tsyringe";
+import { IValidator, StepConfigValidator } from "./validation";
+import { CCXTStep, StepType } from "./types";
+import {
+   ExchangeServiceRepo,
+   IExchangeServiceRepo,
+   ExchangeFactory,
+   IExchangeFactory,
+} from "./exchanges";
+import {
+   ExchangeSwapValidationStrategy,
+   WithdrawCryptoValidationStrategy,
+} from "./validation/strategies";
+
+export class DependencyRegistrar {
+   private static instance: DependencyRegistrar | null = null;
+
+   private constructor() {}
+
+   public static getInstance(): DependencyRegistrar {
+      if (!this.instance) {
+         this.instance = new DependencyRegistrar();
+      }
+      return this.instance;
+   }
+
+   public configure(): void {
+      this.registerExchangeServices();
+      this.registerValidation();
+   }
+
+   private registerValidation(): void {
+      container.register<IValidator<CCXTStep>>(StepConfigValidator, {
+         useClass: StepConfigValidator,
+      });
+
+      // Register the valiation strategies
+      container.register("ValidationStrategies", {
+         useFactory: (c) => {
+            const map = new Map();
+            map.set(
+               StepType.ExchangeSwap,
+               c.resolve(ExchangeSwapValidationStrategy)
+            );
+            map.set(
+               StepType.ExchangeWithdrawCrypto,
+               c.resolve(WithdrawCryptoValidationStrategy)
+            );
+            return map;
+         },
+      });
+   }
+
+   private registerExchangeServices(): void {
+      container.registerSingleton<IExchangeServiceRepo>(ExchangeServiceRepo);
+
+      container.register<IExchangeFactory>(ExchangeFactory, {
+         useClass: ExchangeFactory,
+      });
+
+      // Note: Individual exchange services are managed by the ExchangeServiceRepo repo,
+      // so we don't need to register them here
+   }
+}

--- a/packages/adapter-ccxt/src/constants/ErrorMessages.ts
+++ b/packages/adapter-ccxt/src/constants/ErrorMessages.ts
@@ -10,7 +10,7 @@ export const ERR_API_BALANCE_FETCH_FAILURE = (currency: string) =>
    `Failed to fetch balance for currency: ${currency}`;
 export const ERR_BALANCE_NOT_FOUND = "Currency balance was not found";
 export const ERR_EXCHANGE_SERVICE_NOT_FOUND = (exchange: string) =>
-   `Service for exchange "${exchange}" not found. It might not have been initialized or properly registered in repo.`;
+   `Service for exchange "${exchange}" not found. Verify the configuration for the ${exchange} exchange has been added to the config file.`;
 export const ERR_API_FETCH_MARKETS_FAILURE = (exchange: string) =>
    `Failed to fetch markets for exchange ${exchange}`;
 export const ERR_INVALID_ADDRESS = (address: string, prop: string) =>

--- a/packages/adapter-ccxt/src/constants/ErrorMessages.ts
+++ b/packages/adapter-ccxt/src/constants/ErrorMessages.ts
@@ -13,3 +13,9 @@ export const ERR_EXCHANGE_SERVICE_NOT_FOUND = (exchange: string) =>
    `Service for exchange "${exchange}" not found. It might not have been initialized or properly registered in repo.`;
 export const ERR_API_FETCH_MARKETS_FAILURE = (exchange: string) =>
    `Failed to fetch markets for exchange ${exchange}`;
+export const ERR_INVALID_ADDRESS = (address: string, prop: string) =>
+   `Invalid address was provided for property "${prop}": ${address}`;
+export const ERR_EXCHANGE_UNSUPPORTED_MARKET = (
+   exchange: string,
+   market: string
+) => `Market ${market} not supported on exchange ${exchange}`;

--- a/packages/adapter-ccxt/src/constants/InjectionTokens.ts
+++ b/packages/adapter-ccxt/src/constants/InjectionTokens.ts
@@ -1,0 +1,5 @@
+/**
+ * Contains string tokens used for dependency injection in the application when we cannot use a class constructor.
+ */
+
+export const VALIDATION_STRATEGIES_TOKEN = "ValidationStrategies";

--- a/packages/adapter-ccxt/src/constants/index.ts
+++ b/packages/adapter-ccxt/src/constants/index.ts
@@ -1,1 +1,2 @@
 export * from "./ErrorMessages";
+export * from "./InjectionTokens";

--- a/packages/adapter-ccxt/src/exchanges/BinanceApiService.ts
+++ b/packages/adapter-ccxt/src/exchanges/BinanceApiService.ts
@@ -1,4 +1,3 @@
-import { injectable } from "tsyringe";
 import { Balances, binance } from "ccxt";
 import { IExchangeApiService } from ".";
 import {
@@ -7,7 +6,6 @@ import {
    ERR_BALANCE_NOT_FOUND,
 } from "../constants";
 
-@injectable()
 export class BinanceApiService implements IExchangeApiService {
    constructor(private exchange: binance) {}
 

--- a/packages/adapter-ccxt/src/exchanges/BinanceApiService.ts
+++ b/packages/adapter-ccxt/src/exchanges/BinanceApiService.ts
@@ -46,7 +46,10 @@ export class BinanceApiService implements IExchangeApiService {
    public async isMarketSupported(symbol: string): Promise<boolean> {
       try {
          const markets = await this.exchange.fetchMarkets();
-         return markets.find((market) => market.symbol === symbol);
+         const matchingMarket = markets.find(
+            (market) => market.symbol === symbol
+         );
+         return matchingMarket !== undefined;
       } catch (error) {
          throw new Error(
             `${ERR_API_FETCH_MARKETS_FAILURE(this.exchange.id)}:${error}`

--- a/packages/adapter-ccxt/src/exchanges/BinanceApiService.ts
+++ b/packages/adapter-ccxt/src/exchanges/BinanceApiService.ts
@@ -42,4 +42,15 @@ export class BinanceApiService implements IExchangeApiService {
          throw new Error(`${ERR_API_BALANCE_FETCH_FAILURE(currency)}:${error}`);
       }
    }
+
+   public async isMarketSupported(symbol: string): Promise<boolean> {
+      try {
+         const markets = await this.exchange.fetchMarkets();
+         return markets.find((market) => market.symbol === symbol);
+      } catch (error) {
+         throw new Error(
+            `${ERR_API_FETCH_MARKETS_FAILURE(this.exchange.id)}:${error}`
+         );
+      }
+   }
 }

--- a/packages/adapter-ccxt/src/exchanges/ExchangeServiceRepo.ts
+++ b/packages/adapter-ccxt/src/exchanges/ExchangeServiceRepo.ts
@@ -1,9 +1,9 @@
-import { singleton } from "tsyringe";
+import { injectable } from "tsyringe";
 import { ExchangeId } from "../types";
 import { IExchangeApiService } from "./IExchangeApiService";
 import { IExchangeServiceRepo } from "./IExchangeServiceRepo";
 
-@singleton()
+@injectable()
 export class ExchangeServiceRepo implements IExchangeServiceRepo {
    private exchangeServices: Map<ExchangeId, IExchangeApiService>;
 

--- a/packages/adapter-ccxt/src/exchanges/IExchangeApiService.ts
+++ b/packages/adapter-ccxt/src/exchanges/IExchangeApiService.ts
@@ -14,4 +14,11 @@ export interface IExchangeApiService {
     * @returns A Promise that resolves to true if the asset is supported, false otherwise.
     */
    isAssetSupported(asset: string): Promise<boolean>;
+
+   /**
+    * Determines if the specified market is supported by the exchange.
+    * @param symbol - The symbol of the market (e.g., "BTC/USD", "ETH/BTC", "ETH/USD").
+    * @returns A Promise that resolves to true if the market is supported, false otherwise.
+    */
+   isMarketSupported(symbol: string): Promise<boolean>;
 }

--- a/packages/adapter-ccxt/src/exchanges/index.ts
+++ b/packages/adapter-ccxt/src/exchanges/index.ts
@@ -3,3 +3,4 @@ export * from "./IExchangeFactory";
 export * from "./BinanceApiService";
 export * from "./IExchangeServiceRepo";
 export * from "./ExchangeServiceRepo";
+export * from "./ExchangeFactory";

--- a/packages/adapter-ccxt/src/index.ts
+++ b/packages/adapter-ccxt/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./CCXTAdapter";
+export * from "./DependencyRegistrar";

--- a/packages/adapter-ccxt/src/types/ConfigCodecs.ts
+++ b/packages/adapter-ccxt/src/types/ConfigCodecs.ts
@@ -1,5 +1,5 @@
 import * as t from "io-ts";
-import { StepType } from ".";
+import { Side, StepType } from ".";
 import { TypeOf } from "io-ts";
 
 // Codecs used for the structural validation of data in the config source.
@@ -35,6 +35,8 @@ export const AdapterConfigCodec = t.type({
    config: CCXTAdapterConfigCodec, // Configuration specific to this adapter
 });
 
+// ---- Exchange.Swap ---- //
+
 /**
  * Codec for the Exchange.WithdrawCrypto configuration.
  */
@@ -55,15 +57,18 @@ export const ExchangeWithdrawCrypto = t.type({
    config: ExchangeWithdrawCryptoConfigCodec,
 });
 
+// ---- Exchange.Swap ---- //
+
 /**
  * Codec for the Exchange.Swap configuration.
  */
 export const ExchangeSwapConfigCodec = t.type({
-   exchange: t.string,
-   from: t.string,
-   to: t.string,
-   maxSlippageBPS: t.number,
-   amount: t.number,
+   exchange: t.string, // Identifier for the exchange
+   base: t.string, // Base asset e.g. "BTC"
+   quote: t.string, // Quote asset e.g. "USDT"
+   side: t.union([t.literal(Side.Buy), t.literal(Side.Sell)]), // Side of the order
+   maxSlippageBPS: t.number, // Maximum slippage in basis points
+   amount: t.number, // Amount to swap
 });
 
 /**

--- a/packages/adapter-ccxt/src/types/ConfigCodecs.ts
+++ b/packages/adapter-ccxt/src/types/ConfigCodecs.ts
@@ -1,5 +1,6 @@
 import * as t from "io-ts";
-import { Side, StepType } from ".";
+import { StepType } from ".";
+import { Side } from "./Side";
 import { TypeOf } from "io-ts";
 
 // Codecs used for the structural validation of data in the config source.

--- a/packages/adapter-ccxt/src/types/Side.ts
+++ b/packages/adapter-ccxt/src/types/Side.ts
@@ -1,0 +1,4 @@
+export enum Side {
+   Buy = "Buy",
+   Sell = "Sell",
+}

--- a/packages/adapter-ccxt/src/types/index.ts
+++ b/packages/adapter-ccxt/src/types/index.ts
@@ -3,3 +3,4 @@ export * from "./ExchangeId";
 export * from "./ChainId";
 export * from "./StepType";
 export * from "./ConfigCodecs";
+export * from "./Side";

--- a/packages/adapter-ccxt/src/validation/StepConfigValidator.ts
+++ b/packages/adapter-ccxt/src/validation/StepConfigValidator.ts
@@ -1,35 +1,18 @@
-import { injectable } from "tsyringe";
-import {
-   IValidator,
-   ValidationError,
-   ERR_INVALID_STEP_CONFIG,
-   ERR_UNSUPPORTED_STEP,
-   ERR_UNSUPPORTED_CHAIN,
-   ERR_INVALID_ADDRESS,
-} from "@mate/sdk";
+import { inject, injectable } from "tsyringe";
+import { IValidator } from "./IValidator";
 import { isRight } from "fp-ts/lib/Either";
 import { PathReporter } from "io-ts/lib/PathReporter";
-import {
-   CCXTStep,
-   CCXTStepConfig,
-   ChainId,
-   ExchangeId,
-   StepType,
-} from "../types";
-import { IExchangeServiceRepo } from "../exchanges";
-import {
-   ERR_ASSET_UNSUPPORTED_ON_EXCHANGE,
-   ERR_EXCHANGE_SERVICE_NOT_FOUND,
-   ERR_UNSUPPORTED_EXCHANGE,
-} from "../constants";
-import { isAddress } from "viem";
+import { ValidationError } from "./ValidationError";
+import { CCXTStep, CCXTStepConfig, StepType } from "../types";
+import { ERR_INVALID_STEP_CONFIG, ERR_UNSUPPORTED_STEP } from "@mate/sdk";
+import { IStepValidationStrategy } from "./strategies";
 
 @injectable()
 export class StepConfigValidator implements IValidator<CCXTStep> {
-   private chainIdSet = new Set(Object.values(ChainId));
-   private exchangeIdSet = new Set(Object.values(ExchangeId));
-
-   constructor(private exchangeServiceRepo: IExchangeServiceRepo) {}
+   constructor(
+      @inject("ValidationStrategies")
+      private strategies: Map<StepType, IStepValidationStrategy>
+   ) {}
 
    public async validate(data: any): Promise<CCXTStep> {
       const validationResult = CCXTStepConfig.decode(data);
@@ -45,85 +28,15 @@ export class StepConfigValidator implements IValidator<CCXTStep> {
    }
 
    private async processValidResult(validResult: CCXTStep): Promise<CCXTStep> {
-      //TODO: Refactor to use strategies for validation so we can add new step types without modifying this.
-      switch (validResult.type) {
-         case StepType.ExchangeWithdrawCrypto:
-            // Validate exchange
-            this.validateEnumValue(
-               validResult.config.exchange,
-               this.exchangeIdSet,
-               ERR_UNSUPPORTED_EXCHANGE
-            );
+      const strategy = this.strategies.get(validResult.type);
 
-            // Validate chain
-            this.validateEnumValue(
-               validResult.config.chainId,
-               this.chainIdSet,
-               ERR_UNSUPPORTED_CHAIN
-            );
-
-            // Validate asset
-            await this.validateExchangeAsset(
-               validResult.config.asset,
-               validResult.config.exchange as ExchangeId
-            );
-
-            //Validate address
-            this.validateAddress(validResult.config.destinationAddress);
-
-            break;
-         default:
-            // This should only happen if a new step type is added without updating this code.
-            throw new ValidationError(
-               this.prependGeneralError(ERR_UNSUPPORTED_STEP(validResult.type))
-            );
+      if (strategy) {
+         return strategy.validate(validResult);
       }
 
-      return validResult;
-   }
-
-   private validateAddress(address: string): void {
-      if (!isAddress(address)) {
-         throw new ValidationError(
-            this.prependGeneralError(
-               ERR_INVALID_ADDRESS(address, "destinationAddress")
-            )
-         );
-      }
-   }
-
-   private validateEnumValue(
-      value: string,
-      validSet: Set<string>,
-      errorFunc: (val: string) => string
-   ): void {
-      if (!validSet.has(value)) {
-         throw new ValidationError(this.prependGeneralError(errorFunc(value)));
-      }
-   }
-
-   private async validateExchangeAsset(
-      asset: string,
-      exchange: ExchangeId
-   ): Promise<void> {
-      const exchangeService =
-         this.exchangeServiceRepo.getExchangeService(exchange);
-
-      if (!exchangeService) {
-         throw new ValidationError(
-            this.prependGeneralError(ERR_EXCHANGE_SERVICE_NOT_FOUND(exchange))
-         );
-      }
-
-      const isSupported = await exchangeService.isAssetSupported(asset);
-
-      if (!isSupported) {
-         throw new ValidationError(
-            this.prependGeneralError(
-               ERR_ASSET_UNSUPPORTED_ON_EXCHANGE(asset, exchange)
-            )
-         );
-      }
+      throw new ValidationError(
+         this.prependGeneralError(ERR_UNSUPPORTED_STEP(validResult.type))
+      );
    }
 
    private prependGeneralError(specificError: string): string {

--- a/packages/adapter-ccxt/src/validation/StepConfigValidator.ts
+++ b/packages/adapter-ccxt/src/validation/StepConfigValidator.ts
@@ -4,13 +4,14 @@ import { isRight } from "fp-ts/lib/Either";
 import { PathReporter } from "io-ts/lib/PathReporter";
 import { ValidationError } from "./ValidationError";
 import { CCXTStep, CCXTStepConfig, StepType } from "../types";
+import { VALIDATION_STRATEGIES_TOKEN } from "../constants";
 import { ERR_INVALID_STEP_CONFIG, ERR_UNSUPPORTED_STEP } from "@mate/sdk";
 import { IStepValidationStrategy } from "./strategies";
 
 @injectable()
 export class StepConfigValidator implements IValidator<CCXTStep> {
    constructor(
-      @inject("ValidationStrategies")
+      @inject(VALIDATION_STRATEGIES_TOKEN)
       private strategies: Map<StepType, IStepValidationStrategy>
    ) {}
 

--- a/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
@@ -9,7 +9,9 @@ import { ValidationError } from "../ValidationError";
 import { IExchangeServiceRepo } from "../../exchanges";
 import { TypeOf } from "io-ts";
 import { IStepValidationStrategy } from "./IStepValidationStrategy";
+import { injectable } from "tsyringe";
 
+@injectable()
 export class ExchangeSwapValidationStrategy implements IStepValidationStrategy {
    constructor(private exchangeServiceRepo: IExchangeServiceRepo) {}
 

--- a/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
@@ -1,0 +1,73 @@
+import { CCXTStep, ExchangeId, ExchangeSwapConfigCodec } from "../../types";
+import {
+   ERR_EXCHANGE_SERVICE_NOT_FOUND,
+   ERR_EXCHANGE_UNSUPPORTED_MARKET,
+   ERR_INVALID_STEP_CONFIG,
+   ERR_UNSUPPORTED_EXCHANGE,
+} from "../../constants";
+import { ValidationError } from "../ValidationError";
+import { IExchangeServiceRepo } from "../../exchanges";
+import { TypeOf } from "io-ts";
+import { IStepValidationStrategy } from "./IStepValidationStrategy";
+
+export class ExchangeSwapValidationStrategy implements IStepValidationStrategy {
+   constructor(private exchangeServiceRepo: IExchangeServiceRepo) {}
+
+   public async validate(validResult: CCXTStep): Promise<CCXTStep> {
+      const config = validResult.config as TypeOf<
+         typeof ExchangeSwapConfigCodec
+      >;
+
+      // Validate exchange
+      this.validateExchange(config.exchange);
+
+      // Validate market
+      this.validateMarket(
+         config.base,
+         config.quote,
+         config.exchange as ExchangeId
+      );
+
+      return validResult;
+   }
+
+   private validateExchange(exchange: string): void {
+      if (!new Set(Object.values(ExchangeId)).has(exchange as ExchangeId)) {
+         throw new ValidationError(
+            this.prependGeneralError(ERR_UNSUPPORTED_EXCHANGE(exchange))
+         );
+      }
+   }
+
+   private validateMarket(
+      base: string,
+      quote: string,
+      exchangeId: ExchangeId
+   ): void {
+      const exchangeService =
+         this.exchangeServiceRepo.getExchangeService(exchangeId);
+
+      if (!exchangeService) {
+         throw new ValidationError(
+            this.prependGeneralError(ERR_EXCHANGE_SERVICE_NOT_FOUND(exchangeId))
+         );
+      }
+
+      const normalizedBase = base.trim().toUpperCase();
+      const normalizedQuote = quote.trim().toUpperCase();
+
+      const symbol = `${normalizedBase}/${normalizedQuote}`;
+
+      if (!exchangeService.isMarketSupported(symbol)) {
+         throw new ValidationError(
+            this.prependGeneralError(
+               ERR_EXCHANGE_UNSUPPORTED_MARKET(exchangeId, symbol)
+            )
+         );
+      }
+   }
+
+   private prependGeneralError(specificError: string): string {
+      return `${ERR_INVALID_STEP_CONFIG}: ${specificError}`;
+   }
+}

--- a/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
@@ -6,14 +6,17 @@ import {
    ERR_UNSUPPORTED_EXCHANGE,
 } from "../../constants";
 import { ValidationError } from "../ValidationError";
-import { IExchangeServiceRepo } from "../../exchanges";
+import { ExchangeServiceRepo, IExchangeServiceRepo } from "../../exchanges";
 import { TypeOf } from "io-ts";
 import { IStepValidationStrategy } from "./IStepValidationStrategy";
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 
 @injectable()
 export class ExchangeSwapValidationStrategy implements IStepValidationStrategy {
-   constructor(private exchangeServiceRepo: IExchangeServiceRepo) {}
+   constructor(
+      @inject(ExchangeServiceRepo)
+      private exchangeServiceRepo: IExchangeServiceRepo
+   ) {}
 
    public async validate(validResult: CCXTStep): Promise<CCXTStep> {
       const config = validResult.config as TypeOf<

--- a/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/ExchangeSwapValidationStrategy.ts
@@ -2,7 +2,6 @@ import { CCXTStep, ExchangeId, ExchangeSwapConfigCodec } from "../../types";
 import {
    ERR_EXCHANGE_SERVICE_NOT_FOUND,
    ERR_EXCHANGE_UNSUPPORTED_MARKET,
-   ERR_INVALID_STEP_CONFIG,
    ERR_UNSUPPORTED_EXCHANGE,
 } from "../../constants";
 import { ValidationError } from "../ValidationError";
@@ -10,6 +9,7 @@ import { ExchangeServiceRepo, IExchangeServiceRepo } from "../../exchanges";
 import { TypeOf } from "io-ts";
 import { IStepValidationStrategy } from "./IStepValidationStrategy";
 import { inject, injectable } from "tsyringe";
+import { ERR_INVALID_STEP_CONFIG } from "@mate/sdk";
 
 @injectable()
 export class ExchangeSwapValidationStrategy implements IStepValidationStrategy {

--- a/packages/adapter-ccxt/src/validation/strategies/IStepValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/IStepValidationStrategy.ts
@@ -1,0 +1,21 @@
+import { CCXTStep } from "../../types";
+
+/**
+ * Represents a strategy for validating a specific type of step supported by the adapter.
+ *
+ * This interface enforces a `validate` method that each concrete step validation
+ * strategy must implement to provide the specific validation logic for a particular step type.
+ *
+ * This allows the addition of new step types by simply adding new strategies that adhere to this interface, without
+ * the need to modify existing validation logic.
+ */
+export interface IStepValidationStrategy {
+   /**
+    * Validates the provided CCXTStep according to the specific rules and logic of the strategy.
+    *
+    * @param validResult - The CCXTStep instance to be validated.
+    * @returns A promise that resolves to the validated CCXTStep instance.
+    * @throws ValidationError if the validation fails for any reason.
+    */
+   validate(validResult: CCXTStep): Promise<CCXTStep>;
+}

--- a/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
@@ -8,8 +8,6 @@ import {
    ERR_ASSET_UNSUPPORTED_ON_EXCHANGE,
    ERR_EXCHANGE_SERVICE_NOT_FOUND,
    ERR_INVALID_ADDRESS,
-   ERR_INVALID_STEP_CONFIG,
-   ERR_UNSUPPORTED_CHAIN,
    ERR_UNSUPPORTED_EXCHANGE,
 } from "../../constants";
 import { isAddress } from "viem";
@@ -18,6 +16,7 @@ import { ExchangeServiceRepo, IExchangeServiceRepo } from "../../exchanges";
 import { TypeOf } from "io-ts";
 import { IStepValidationStrategy } from "./IStepValidationStrategy";
 import { inject, injectable } from "tsyringe";
+import { ERR_INVALID_STEP_CONFIG, ERR_UNSUPPORTED_CHAIN } from "@mate/sdk";
 
 @injectable()
 export class WithdrawCryptoValidationStrategy

--- a/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
@@ -33,6 +33,9 @@ export class WithdrawCryptoValidationStrategy
          typeof ExchangeWithdrawCryptoConfigCodec
       >;
 
+      //Validate address
+      this.validateAddress(config.destinationAddress);
+
       // Validate exchange
       this.validateEnumValue(
          config.exchange,
@@ -52,9 +55,6 @@ export class WithdrawCryptoValidationStrategy
          config.asset,
          config.exchange as ExchangeId
       );
-
-      //Validate address
-      this.validateAddress(config.destinationAddress);
 
       return validResult;
    }

--- a/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
@@ -17,7 +17,9 @@ import { ValidationError } from "../ValidationError";
 import { IExchangeServiceRepo } from "../../exchanges";
 import { TypeOf } from "io-ts";
 import { IStepValidationStrategy } from "./IStepValidationStrategy";
+import { injectable } from "tsyringe";
 
+@injectable()
 export class WithdrawCryptoValidationStrategy
    implements IStepValidationStrategy
 {

--- a/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
@@ -1,0 +1,107 @@
+import {
+   CCXTStep,
+   ChainId,
+   ExchangeId,
+   ExchangeWithdrawCryptoConfigCodec,
+} from "../../types";
+import {
+   ERR_ASSET_UNSUPPORTED_ON_EXCHANGE,
+   ERR_EXCHANGE_SERVICE_NOT_FOUND,
+   ERR_INVALID_ADDRESS,
+   ERR_INVALID_STEP_CONFIG,
+   ERR_UNSUPPORTED_CHAIN,
+   ERR_UNSUPPORTED_EXCHANGE,
+} from "../../constants";
+import { isAddress } from "viem";
+import { ValidationError } from "../ValidationError";
+import { IExchangeServiceRepo } from "../../exchanges";
+import { TypeOf } from "io-ts";
+import { IStepValidationStrategy } from "./IStepValidationStrategy";
+
+export class WithdrawCryptoValidationStrategy
+   implements IStepValidationStrategy
+{
+   private chainIdSet = new Set(Object.values(ChainId));
+   private exchangeIdSet = new Set(Object.values(ExchangeId));
+
+   constructor(private exchangeServiceRepo: IExchangeServiceRepo) {}
+
+   public async validate(validResult: CCXTStep): Promise<CCXTStep> {
+      const config = validResult.config as TypeOf<
+         typeof ExchangeWithdrawCryptoConfigCodec
+      >;
+
+      // Validate exchange
+      this.validateEnumValue(
+         config.exchange,
+         this.exchangeIdSet,
+         ERR_UNSUPPORTED_EXCHANGE
+      );
+
+      // Validate chain
+      this.validateEnumValue(
+         config.chainId,
+         this.chainIdSet,
+         ERR_UNSUPPORTED_CHAIN
+      );
+
+      // Validate asset
+      await this.validateExchangeAsset(
+         config.asset,
+         config.exchange as ExchangeId
+      );
+
+      //Validate address
+      this.validateAddress(config.destinationAddress);
+
+      return validResult;
+   }
+
+   private validateAddress(address: string): void {
+      if (!isAddress(address)) {
+         throw new ValidationError(
+            this.prependGeneralError(
+               ERR_INVALID_ADDRESS(address, "destinationAddress")
+            )
+         );
+      }
+   }
+
+   private validateEnumValue(
+      value: string,
+      validSet: Set<string>,
+      errorFunc: (val: string) => string
+   ): void {
+      if (!validSet.has(value)) {
+         throw new ValidationError(this.prependGeneralError(errorFunc(value)));
+      }
+   }
+
+   private async validateExchangeAsset(
+      asset: string,
+      exchange: ExchangeId
+   ): Promise<void> {
+      const exchangeService =
+         this.exchangeServiceRepo.getExchangeService(exchange);
+
+      if (!exchangeService) {
+         throw new ValidationError(
+            this.prependGeneralError(ERR_EXCHANGE_SERVICE_NOT_FOUND(exchange))
+         );
+      }
+
+      const isSupported = await exchangeService.isAssetSupported(asset);
+
+      if (!isSupported) {
+         throw new ValidationError(
+            this.prependGeneralError(
+               ERR_ASSET_UNSUPPORTED_ON_EXCHANGE(asset, exchange)
+            )
+         );
+      }
+   }
+
+   private prependGeneralError(specificError: string): string {
+      return `${ERR_INVALID_STEP_CONFIG}: ${specificError}`;
+   }
+}

--- a/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/WithdrawCryptoValidationStrategy.ts
@@ -14,10 +14,10 @@ import {
 } from "../../constants";
 import { isAddress } from "viem";
 import { ValidationError } from "../ValidationError";
-import { IExchangeServiceRepo } from "../../exchanges";
+import { ExchangeServiceRepo, IExchangeServiceRepo } from "../../exchanges";
 import { TypeOf } from "io-ts";
 import { IStepValidationStrategy } from "./IStepValidationStrategy";
-import { injectable } from "tsyringe";
+import { inject, injectable } from "tsyringe";
 
 @injectable()
 export class WithdrawCryptoValidationStrategy
@@ -26,7 +26,10 @@ export class WithdrawCryptoValidationStrategy
    private chainIdSet = new Set(Object.values(ChainId));
    private exchangeIdSet = new Set(Object.values(ExchangeId));
 
-   constructor(private exchangeServiceRepo: IExchangeServiceRepo) {}
+   constructor(
+      @inject(ExchangeServiceRepo)
+      private exchangeServiceRepo: IExchangeServiceRepo
+   ) {}
 
    public async validate(validResult: CCXTStep): Promise<CCXTStep> {
       const config = validResult.config as TypeOf<

--- a/packages/adapter-ccxt/src/validation/strategies/index.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/index.ts
@@ -1,2 +1,3 @@
 export * from "./IStepValidationStrategy";
 export * from "./WithdrawCryptoValidationStrategy";
+export * from "./ExchangeSwapValidationStrategy";

--- a/packages/adapter-ccxt/src/validation/strategies/index.ts
+++ b/packages/adapter-ccxt/src/validation/strategies/index.ts
@@ -1,0 +1,2 @@
+export * from "./IStepValidationStrategy";
+export * from "./WithdrawCryptoValidationStrategy";

--- a/packages/adapter-ccxt/test/integration/DependencyRegistrar.integration.test.ts
+++ b/packages/adapter-ccxt/test/integration/DependencyRegistrar.integration.test.ts
@@ -11,9 +11,11 @@ import { StepConfigValidator } from "../../src/validation";
 import {
    ExchangeFactory,
    ExchangeServiceRepo,
+   IExchangeApiService,
    IExchangeFactory,
    IExchangeServiceRepo,
 } from "../../src/exchanges";
+import { VALIDATION_STRATEGIES_TOKEN } from "../../src/constants";
 
 describe("DependencyRegistrar", () => {
    let testee: DependencyRegistrar;
@@ -26,7 +28,7 @@ describe("DependencyRegistrar", () => {
    it("should correctly register the named validation strategies map", async () => {
       const strategies = container.resolve<
          Map<StepType, IStepValidationStrategy>
-      >("ValidationStrategies");
+      >(VALIDATION_STRATEGIES_TOKEN);
 
       expect(strategies.size).toBe(2);
 
@@ -61,7 +63,12 @@ describe("DependencyRegistrar", () => {
       expect(repoInstance).toBeInstanceOf(ExchangeServiceRepo);
 
       // Add an exchange service to the repo
-      const exchangeService = {} as any;
+      const exchangeService: IExchangeApiService = {
+         getCurrencyBalance: () => Promise.resolve(0),
+         isAssetSupported: () => Promise.resolve(true),
+         isMarketSupported: () => Promise.resolve(true),
+      };
+
       repoInstance.setExchangeService(ExchangeId.BINANCE, exchangeService);
 
       // Resolve the repo again and verify it's the same instance

--- a/packages/adapter-ccxt/test/integration/DependencyRegistrar.integration.test.ts
+++ b/packages/adapter-ccxt/test/integration/DependencyRegistrar.integration.test.ts
@@ -1,0 +1,78 @@
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { DependencyRegistrar } from "../../src/DependencyRegistrar";
+import {
+   ExchangeSwapValidationStrategy,
+   IStepValidationStrategy,
+   WithdrawCryptoValidationStrategy,
+} from "../../src/validation/strategies";
+import { ExchangeId, StepType } from "../../src/types";
+import { StepConfigValidator } from "../../src/validation";
+import {
+   ExchangeFactory,
+   ExchangeServiceRepo,
+   IExchangeFactory,
+   IExchangeServiceRepo,
+} from "../../src/exchanges";
+
+describe("DependencyRegistrar", () => {
+   let testee: DependencyRegistrar;
+
+   beforeAll(() => {
+      testee = DependencyRegistrar.getInstance();
+      testee.configure();
+   });
+
+   it("should correctly register the named validation strategies map", async () => {
+      const strategies = container.resolve<
+         Map<StepType, IStepValidationStrategy>
+      >("ValidationStrategies");
+
+      expect(strategies.size).toBe(2);
+
+      expect(strategies.has(StepType.ExchangeSwap)).toBe(true);
+      expect(strategies.has(StepType.ExchangeWithdrawCrypto)).toBe(true);
+
+      expect(strategies.get(StepType.ExchangeSwap)).toBeInstanceOf(
+         ExchangeSwapValidationStrategy
+      );
+      expect(strategies.get(StepType.ExchangeWithdrawCrypto)).toBeInstanceOf(
+         WithdrawCryptoValidationStrategy
+      );
+   });
+
+   it("should correctly register the StepConfigValidator", async () => {
+      const validator =
+         container.resolve<IStepValidationStrategy>(StepConfigValidator);
+
+      expect(validator).toBeInstanceOf(StepConfigValidator);
+   });
+
+   it("should correctly register the ExchangeFactory", async () => {
+      const factory = container.resolve<IExchangeFactory>(ExchangeFactory);
+
+      expect(factory).toBeInstanceOf(ExchangeFactory);
+   });
+
+   it("should correctly register the ExchangeServiceRepo as a singleton", async () => {
+      // Resolve the repo and verify it's an instance of ExchangeServiceRepo
+      const repoInstance =
+         container.resolve<IExchangeServiceRepo>(ExchangeServiceRepo);
+      expect(repoInstance).toBeInstanceOf(ExchangeServiceRepo);
+
+      // Add an exchange service to the repo
+      const exchangeService = {} as any;
+      repoInstance.setExchangeService(ExchangeId.BINANCE, exchangeService);
+
+      // Resolve the repo again and verify it's the same instance
+      const repoInstance2 =
+         container.resolve<IExchangeServiceRepo>(ExchangeServiceRepo);
+      expect(repoInstance2).toBe(repoInstance);
+
+      // Verify the exchange service is retrievable from the second instance
+      const retrievedExchangeService = repoInstance2.getExchangeService(
+         ExchangeId.BINANCE
+      );
+      expect(retrievedExchangeService).toBe(exchangeService);
+   });
+});

--- a/packages/adapter-ccxt/test/integration/exchanges/BinanceApiService.integration.test.ts
+++ b/packages/adapter-ccxt/test/integration/exchanges/BinanceApiService.integration.test.ts
@@ -36,4 +36,16 @@ describe("BinanceApiService Integration", () => {
          expect(result).toBeGreaterThan(0);
       });
    });
+
+   describe("isMarketSupported", () => {
+      it("should return true if the market is supported", async () => {
+         const result = await testee.isMarketSupported("BTC/USDT");
+         expect(result).toBeTruthy();
+      });
+
+      it("should return false if the market is not supported", async () => {
+         const result = await testee.isMarketSupported("BTC/MOJIMBO454");
+         expect(result).toBeFalsy();
+      });
+   });
 });

--- a/packages/adapter-ccxt/test/unit/exchanges/BinanceApiService.test.ts
+++ b/packages/adapter-ccxt/test/unit/exchanges/BinanceApiService.test.ts
@@ -120,4 +120,40 @@ describe("BinanceApiService", () => {
          verify(mockBinance.fetchBalance()).once();
       });
    });
+
+   describe("isMarketSupported", () => {
+      it("should return true if the market symbol is supported", async () => {
+         when(mockBinance.fetchMarkets()).thenResolve([
+            { symbol: "BTC/USDT" },
+            { symbol: "ETH/USDT" },
+         ]);
+         const result = await testee.isMarketSupported("BTC/USDT");
+         expect(result).toBe(true);
+         verify(mockBinance.fetchMarkets()).once();
+      });
+
+      it("should return false if the market symbol is not supported", async () => {
+         when(mockBinance.fetchMarkets()).thenResolve([
+            { symbol: "BTC/USDT" },
+            { symbol: "ETH/USDT" },
+         ]);
+         const result = await testee.isMarketSupported("CELO/USDT");
+         expect(result).toBe(false);
+         verify(mockBinance.fetchMarkets()).once();
+      });
+
+      it("should throw an error when fetchMarkets fails", async () => {
+         when(mockBinance.fetchMarkets()).thenThrow(
+            new Error("Network issue for markets")
+         );
+
+         await expect(
+            testee.isMarketSupported("BTC/USDT")
+         ).rejects.toThrowError(
+            `${ERR_API_FETCH_MARKETS_FAILURE(
+               "binance"
+            )}:Error: Network issue for markets`
+         );
+      });
+   });
 });

--- a/packages/adapter-ccxt/test/unit/validation/StepConfigValidator.test.ts
+++ b/packages/adapter-ccxt/test/unit/validation/StepConfigValidator.test.ts
@@ -1,185 +1,73 @@
 import "reflect-metadata";
-import { mock, instance, when, anyString, verify } from "ts-mockito";
-import { ChainId, ExchangeId, StepType } from "../../../src/types";
+import { anything, instance, mock, verify, when } from "ts-mockito";
 import { StepConfigValidator } from "../../../src/validation";
-import {
-   ERR_ASSET_UNSUPPORTED_ON_EXCHANGE,
-   ERR_EXCHANGE_SERVICE_NOT_FOUND,
-   ERR_UNSUPPORTED_EXCHANGE,
-} from "../../../src/constants";
-import {
-   IExchangeApiService,
-   IExchangeServiceRepo,
-} from "../../../src/exchanges";
-import {
-   ERR_INVALID_ADDRESS,
-   ERR_UNSUPPORTED_CHAIN,
-   ERR_UNSUPPORTED_STEP,
-} from "@mate/sdk";
+import { IStepValidationStrategy } from "../../../src/validation/strategies";
+import { CCXTStep, Side, StepType } from "../../../src/types";
+import { ERR_INVALID_STEP_CONFIG, ERR_UNSUPPORTED_STEP } from "@mate/sdk";
 
 describe("StepConfigValidator", () => {
-   let mockExchangeService: IExchangeApiService;
-   let mockExchangeServiceRepo: IExchangeServiceRepo;
-   let testee: StepConfigValidator;
+   let validator: StepConfigValidator;
+   let mockStrategy: IStepValidationStrategy;
+   let mockStrategiesMap: Map<StepType, IStepValidationStrategy>;
 
    beforeEach(() => {
-      mockExchangeServiceRepo = mock<IExchangeServiceRepo>();
-      mockExchangeService = mock<IExchangeApiService>();
-      testee = new StepConfigValidator(instance(mockExchangeServiceRepo));
-
-      // Setup mocks
-      when(mockExchangeService.isAssetSupported(anyString())).thenReturn(
-         Promise.resolve(true)
+      mockStrategy = mock<IStepValidationStrategy>();
+      mockStrategiesMap = new Map<StepType, IStepValidationStrategy>();
+      mockStrategiesMap.set(
+         StepType.ExchangeWithdrawCrypto,
+         instance(mockStrategy)
       );
-      when(mockExchangeServiceRepo.getExchangeService(anyString())).thenReturn(
-         instance(mockExchangeService)
+
+      validator = new StepConfigValidator(mockStrategiesMap);
+   });
+
+   it("should validate using the correct strategy when data is valid", async () => {
+      const validData: CCXTStep = {
+         type: StepType.ExchangeWithdrawCrypto,
+         adapter: "ccxt",
+         config: {
+            exchange: "test-exchange",
+            asset: "BTC",
+            chainId: "test-chain",
+            destinationAddress: "test-address",
+            amount: 123,
+         },
+      };
+
+      when(mockStrategy.validate(anything())).thenResolve(validData);
+
+      const result = await validator.validate(validData);
+      expect(result).toEqual(validData);
+
+      verify(mockStrategy.validate(validData)).once();
+   });
+
+   it("should throw ValidationError on invalid data structure", async () => {
+      const invalidConfig = {
+         type: "Tall, dark & handsome",
+      };
+
+      await expect(validator.validate(invalidConfig)).rejects.toThrow(
+         ERR_INVALID_STEP_CONFIG
       );
    });
 
-   describe("validate", () => {
-      it("should throw ValidationError for invalid config", async () => {
-         const invalidConfig = {};
+   it("should throw ValidationError when no strategy found for a step type", async () => {
+      const dataWithNoStrategy: CCXTStep = {
+         type: StepType.ExchangeSwap,
+         adapter: "ccxt",
+         config: {
+            exchange: "test-exchange",
+            base: "BTC",
+            quote: "USDT",
+            side: Side.Buy,
+            maxSlippageBPS: 100,
+            amount: 123,
+         },
+      };
 
-         await expect(testee.validate(invalidConfig)).rejects.toThrow(
-            "Invalid step configuration provided"
-         );
-      });
-
-      it("should throw ValidationError for unsupported exchange", async () => {
-         const invalidConfig = {
-            type: StepType.ExchangeWithdrawCrypto,
-            adapter: "ccxt",
-            config: {
-               exchange: "ftx",
-               asset: "BTC",
-               chainId: ChainId.CELO,
-               destinationAddress: "some address",
-               amount: 5000,
-            },
-         };
-
-         await expect(() => testee.validate(invalidConfig)).rejects.toThrow(
-            `${ERR_UNSUPPORTED_EXCHANGE("ftx")}`
-         );
-      });
-
-      it("should throw ValidationError for unsupported chain", async () => {
-         const invalidConfig = {
-            type: StepType.ExchangeWithdrawCrypto,
-            adapter: "ccxt",
-            config: {
-               exchange: ExchangeId.BINANCE,
-               asset: "BTC",
-               chainId: "1",
-               destinationAddress: "some address",
-               amount: 5000,
-            },
-         };
-
-         await expect(() => testee.validate(invalidConfig)).rejects.toThrow(
-            `${ERR_UNSUPPORTED_CHAIN("1")}`
-         );
-      });
-
-      it("should throw ValidationError for unsupported step", async () => {
-         const invalidConfig = {
-            type: StepType.ExchangeSwap,
-            adapter: "ccxt",
-            config: {
-               exchange: ExchangeId.BINANCE,
-               from: "BTC",
-               to: "1",
-               maxSlippageBPS: 1,
-               amount: 5000,
-            },
-         };
-
-         await expect(() => testee.validate(invalidConfig)).rejects.toThrow(
-            `${ERR_UNSUPPORTED_STEP("Exchange.Swap")}`
-         );
-      });
-
-      it("should throw ValidationError when exchange does not support asset", async () => {
-         const invalidConfig = {
-            type: StepType.ExchangeWithdrawCrypto,
-            adapter: "ccxt",
-            config: {
-               exchange: ExchangeId.BINANCE,
-               asset: "BTC",
-               chainId: ChainId.CELO,
-               destinationAddress: "some address",
-               amount: 5000,
-            },
-         };
-
-         when(mockExchangeService.isAssetSupported(anyString())).thenReturn(
-            Promise.resolve(false)
-         );
-
-         await expect(() => testee.validate(invalidConfig)).rejects.toThrow(
-            `${ERR_ASSET_UNSUPPORTED_ON_EXCHANGE("BTC", ExchangeId.BINANCE)}`
-         );
-      });
-
-      it("should throw ValidationError when exchange service is not found", async () => {
-         const invalidConfig = {
-            type: StepType.ExchangeWithdrawCrypto,
-            adapter: "ccxt",
-            config: {
-               exchange: ExchangeId.BINANCE,
-               asset: "BTC",
-               chainId: ChainId.CELO,
-               destinationAddress: "some address",
-               amount: 5000,
-            },
-         };
-
-         when(
-            mockExchangeServiceRepo.getExchangeService(ExchangeId.BINANCE)
-         ).thenReturn(undefined);
-
-         await expect(() => testee.validate(invalidConfig)).rejects.toThrow(
-            `${ERR_EXCHANGE_SERVICE_NOT_FOUND(ExchangeId.BINANCE)}`
-         );
-      });
-
-      it("should throw ValidationError when an invalid destination address is used", async () => {
-         const invalidConfig = {
-            type: StepType.ExchangeWithdrawCrypto,
-            adapter: "ccxt",
-            config: {
-               exchange: ExchangeId.BINANCE,
-               asset: "BTC",
-               chainId: ChainId.CELO,
-               destinationAddress: "Some Address",
-               amount: 5000,
-            },
-         };
-
-         await expect(() => testee.validate(invalidConfig)).rejects.toThrow(
-            `${ERR_INVALID_ADDRESS("Some Address", "destinationAddress")}`
-         );
-      });
-
-      it("should validate successfully for correct config", async () => {
-         const validConfig = {
-            type: StepType.ExchangeWithdrawCrypto,
-            adapter: "ccxt",
-            config: {
-               exchange: ExchangeId.BINANCE,
-               asset: "BTC",
-               chainId: ChainId.CELO,
-               destinationAddress: "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5",
-               amount: 5000,
-            },
-         };
-
-         const result = await testee.validate(validConfig);
-
-         expect(result).toEqual(validConfig);
-         verify(
-            mockExchangeServiceRepo.getExchangeService(ExchangeId.BINANCE)
-         ).once();
-      });
+      await expect(validator.validate(dataWithNoStrategy)).rejects.toThrow(
+         ERR_UNSUPPORTED_STEP(StepType.ExchangeSwap)
+      );
    });
 });

--- a/packages/adapter-ccxt/test/unit/validation/strategies/ExchangeSwapValidationStrategy.test.ts
+++ b/packages/adapter-ccxt/test/unit/validation/strategies/ExchangeSwapValidationStrategy.test.ts
@@ -1,0 +1,117 @@
+import "reflect-metadata";
+import { mock, instance, when, anything } from "ts-mockito";
+import { ExchangeSwapValidationStrategy } from "../../../../src/validation/strategies";
+import {
+   ERR_EXCHANGE_SERVICE_NOT_FOUND,
+   ERR_EXCHANGE_UNSUPPORTED_MARKET,
+   ERR_UNSUPPORTED_EXCHANGE,
+} from "../../../../src/constants";
+import { CCXTStep, ExchangeId, Side, StepType } from "../../../../src/types";
+import {
+   IExchangeApiService,
+   IExchangeServiceRepo,
+} from "../../../../src/exchanges";
+
+describe("ExchangeSwapValidationStrategy", () => {
+   let mockExchangeServiceRepo: IExchangeServiceRepo;
+   let mockExchangeService: IExchangeApiService;
+   let testee: ExchangeSwapValidationStrategy;
+
+   beforeEach(() => {
+      mockExchangeServiceRepo = mock<IExchangeServiceRepo>();
+      mockExchangeService = mock<IExchangeApiService>();
+      testee = new ExchangeSwapValidationStrategy(
+         instance(mockExchangeServiceRepo)
+      );
+   });
+
+   it("should throw ValidationError for unsupported exchange", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeSwap,
+         adapter: "ccxt",
+         config: {
+            exchange: "test-exchange",
+            base: "BTC",
+            quote: "USDT",
+            side: Side.Buy,
+            maxSlippageBPS: 0.01,
+            amount: 123,
+         },
+      };
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_UNSUPPORTED_EXCHANGE("test-exchange")
+      );
+   });
+
+   it("should throw ValidationError for unsupported market", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeSwap,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            base: "BTC",
+            quote: "USD",
+            side: Side.Buy,
+            maxSlippageBPS: 0.01,
+            amount: 123,
+         },
+      };
+
+      when(mockExchangeServiceRepo.getExchangeService(anything())).thenReturn(
+         instance(mockExchangeService)
+      );
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_EXCHANGE_UNSUPPORTED_MARKET(ExchangeId.BINANCE, `BTC/USD`)
+      );
+   });
+
+   it("should throw ValidationError if exchange service not found", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeSwap,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            base: "BTC",
+            quote: "USD",
+            side: Side.Buy,
+            maxSlippageBPS: 0.01,
+            amount: 123,
+         },
+      };
+
+      when(
+         mockExchangeServiceRepo.getExchangeService(ExchangeId.BINANCE)
+      ).thenReturn(undefined);
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_EXCHANGE_SERVICE_NOT_FOUND(ExchangeId.BINANCE)
+      );
+   });
+
+   it("should return config when validation is successful", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeSwap,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            base: "BTC",
+            quote: "USD",
+            side: Side.Buy,
+            maxSlippageBPS: 0.01,
+            amount: 123,
+         },
+      };
+
+      when(mockExchangeService.isMarketSupported(anything())).thenResolve(true);
+
+      when(mockExchangeServiceRepo.getExchangeService(anything())).thenReturn(
+         instance(mockExchangeService)
+      );
+
+      const result = await testee.validate(step);
+
+      expect(result).toEqual(step);
+   });
+});

--- a/packages/adapter-ccxt/test/unit/validation/strategies/WithdrawCryptoValidationStrategy.test.ts
+++ b/packages/adapter-ccxt/test/unit/validation/strategies/WithdrawCryptoValidationStrategy.test.ts
@@ -1,0 +1,153 @@
+import "reflect-metadata";
+import { mock, instance, when, anything } from "ts-mockito";
+import { WithdrawCryptoValidationStrategy } from "../../../../src/validation/strategies";
+import {
+   ERR_EXCHANGE_SERVICE_NOT_FOUND,
+   ERR_ASSET_UNSUPPORTED_ON_EXCHANGE,
+   ERR_INVALID_ADDRESS,
+   ERR_UNSUPPORTED_EXCHANGE,
+   ERR_UNSUPPORTED_CHAIN,
+} from "../../../../src/constants";
+import { CCXTStep, ChainId, ExchangeId, StepType } from "../../../../src/types";
+import {
+   IExchangeApiService,
+   IExchangeServiceRepo,
+} from "../../../../src/exchanges";
+
+describe("WithdrawCryptoValidationStrategy", () => {
+   let mockExchangeServiceRepo: IExchangeServiceRepo;
+   let mockExchangeService: IExchangeApiService;
+   let testee: WithdrawCryptoValidationStrategy;
+
+   const validTestAddress = "0xcFF428319834eB8d57bEaBd41cf2D535F1347D3b";
+
+   beforeEach(() => {
+      mockExchangeServiceRepo = mock<IExchangeServiceRepo>();
+      mockExchangeService = mock<IExchangeApiService>();
+      testee = new WithdrawCryptoValidationStrategy(
+         instance(mockExchangeServiceRepo)
+      );
+   });
+
+   it("should throw ValidationError for unsupported exchange", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeWithdrawCrypto,
+         adapter: "ccxt",
+         config: {
+            exchange: "test-exchange",
+            asset: "USDC",
+            chainId: ChainId.CELO,
+            destinationAddress: validTestAddress,
+            amount: 123,
+         },
+      };
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_UNSUPPORTED_EXCHANGE("test-exchange")
+      );
+   });
+
+   it("should throw ValidationError for unsupported chain", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeWithdrawCrypto,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            asset: "USDC",
+            chainId: "TESTCHAIN",
+            destinationAddress: validTestAddress,
+            amount: 123,
+         },
+      };
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_UNSUPPORTED_CHAIN("TESTCHAIN")
+      );
+   });
+
+   it("should throw ValidationError for invalid address", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeWithdrawCrypto,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            asset: "USDC",
+            chainId: ChainId.CELO,
+            destinationAddress: "invalid-address",
+            amount: 123,
+         },
+      };
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_INVALID_ADDRESS("invalid-address", "destinationAddress")
+      );
+   });
+
+   it("should throw ValidationError if exchange service not found", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeWithdrawCrypto,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            asset: "BTC",
+            chainId: ChainId.CELO,
+            destinationAddress: validTestAddress,
+            amount: 123,
+         },
+      };
+
+      when(
+         mockExchangeServiceRepo.getExchangeService(ExchangeId.BINANCE)
+      ).thenReturn(undefined);
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_EXCHANGE_SERVICE_NOT_FOUND(ExchangeId.BINANCE)
+      );
+   });
+
+   it("should throw ValidationError for unsupported asset", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeWithdrawCrypto,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            asset: "UNKNOWN_ASSET",
+            chainId: ChainId.CELO,
+            destinationAddress: validTestAddress,
+            amount: 123,
+         },
+      };
+
+      when(mockExchangeServiceRepo.getExchangeService(anything())).thenReturn(
+         instance(mockExchangeService)
+      );
+      when(mockExchangeService.isAssetSupported(anything())).thenResolve(false);
+
+      await expect(testee.validate(step)).rejects.toThrow(
+         ERR_ASSET_UNSUPPORTED_ON_EXCHANGE("UNKNOWN_ASSET", ExchangeId.BINANCE)
+      );
+   });
+
+   it("should return config when validation is successful", async () => {
+      const step: CCXTStep = {
+         type: StepType.ExchangeWithdrawCrypto,
+         adapter: "ccxt",
+         config: {
+            exchange: ExchangeId.BINANCE,
+            asset: "BTC",
+            chainId: ChainId.CELO,
+            destinationAddress: validTestAddress,
+            amount: 123,
+         },
+      };
+
+      when(mockExchangeService.isAssetSupported(anything())).thenResolve(true);
+      when(mockExchangeServiceRepo.getExchangeService(anything())).thenReturn(
+         instance(mockExchangeService)
+      );
+
+      const result = await testee.validate(step);
+
+      expect(result).toEqual(step);
+   });
+});

--- a/packages/adapter-ccxt/test/unit/validation/strategies/WithdrawCryptoValidationStrategy.test.ts
+++ b/packages/adapter-ccxt/test/unit/validation/strategies/WithdrawCryptoValidationStrategy.test.ts
@@ -6,13 +6,13 @@ import {
    ERR_ASSET_UNSUPPORTED_ON_EXCHANGE,
    ERR_INVALID_ADDRESS,
    ERR_UNSUPPORTED_EXCHANGE,
-   ERR_UNSUPPORTED_CHAIN,
 } from "../../../../src/constants";
 import { CCXTStep, ChainId, ExchangeId, StepType } from "../../../../src/types";
 import {
    IExchangeApiService,
    IExchangeServiceRepo,
 } from "../../../../src/exchanges";
+import { ERR_UNSUPPORTED_CHAIN } from "@mate/sdk";
 
 describe("WithdrawCryptoValidationStrategy", () => {
    let mockExchangeServiceRepo: IExchangeServiceRepo;


### PR DESCRIPTION
### Description

This PR adds validation logic for the `Exchange.Swap` step configuration.

### Other changes

- Used strategies for step validation logic. Adding validation logic in future only requires adding a strategy class and updating the container setup. 

### Tested

- Unit tests have been added to verify validation works as expected
- Added integration tests to verify new Binance API calls work as expected

### Related issues

-  Closes #13 

### Backwards compatibility

PR is backward conpatible.
